### PR TITLE
change sendIpc to send

### DIFF
--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -1,6 +1,6 @@
 // electron.d.ts
 export interface ElectronAPI {
-    sendIPC: (channel: string, ...args: any[]) => void;
+    send: (channel: string, ...args: any[]) => void;
     showItemInFolder: (filePath: string) => void;
     openPath: (filePath: string) => Promise<string>;
     beep: () => void;

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,8 +69,6 @@ const createWindow = exports.createWindow = () => {
 
   newWindow.on('close', (event: Event) => {
     event.preventDefault();
-    // console.log('Window closing');
-    console.log("isDocumentEdited", newWindow?.isDocumentEdited());
     newWindow?.destroy();
   });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -10,7 +10,7 @@ import { marked } from 'marked';
 // Expose safe APIs to renderer
 contextBridge.exposeInMainWorld('electronAPI', {
   // IPC functions
-  sendIPC: (channel: string, ...args: any[]) => {
+  send: (channel: string, ...args: any[]) => {
     const validSendChannels = [
       'create-window', 'get-file-from-user', 'save-markdown', 
       'save-html', 'show-context-menu', 'update-title', 'update-document',

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -49,8 +49,8 @@ const updateUserInterface = (isEdited: boolean): void => {
         title = `${title} (Edited)`;
     }
 
-    window.electronAPI.sendIPC('update-title', title);
-    window.electronAPI.sendIPC('update-document', isEdited);
+    window.electronAPI.send('update-title', title);
+    window.electronAPI.send('update-document', isEdited);
 
     saveMarkdownButton.disabled = !isEdited;
     revertButton.disabled = !isEdited;
@@ -66,20 +66,20 @@ markdownView.addEventListener('keyup', (event: Event) => {
 
 markdownView.addEventListener('contextmenu', (event: MouseEvent) => {
     event.preventDefault();
-    window.electronAPI.sendIPC('show-context-menu');
+    window.electronAPI.send('show-context-menu');
 });
 
 newFileButton.addEventListener('click', () => {
     // Invokes createWindow in main process
-    window.electronAPI.sendIPC('create-window');
+    window.electronAPI.send('create-window');
 });
 
 openFileButton.addEventListener('click', () => {
-    window.electronAPI.sendIPC('get-file-from-user');
+    window.electronAPI.send('get-file-from-user');
 });
 
 saveMarkdownButton.addEventListener('click', () => {
-    window.electronAPI.sendIPC('save-markdown', filePath, markdownView.value);
+    window.electronAPI.send('save-markdown', filePath, markdownView.value);
     originalContent = markdownView.value;
 })
 
@@ -89,7 +89,7 @@ revertButton.addEventListener('click', () => {
 })
 
 saveHtmlButton.addEventListener('click', () => {
-    window.electronAPI.sendIPC('save-html', htmlView.innerHTML);
+    window.electronAPI.send('save-html', htmlView.innerHTML);
 });
 
 const showFile = () => {
@@ -112,7 +112,7 @@ openInDefaultButton.addEventListener('click', openInDefaultApplication);
 
 window.electronAPI.on('file-opened', async (event: IpcRendererEvent, file: string, content: string) => {
     if (markdownView.value !== originalContent && originalContent !== content) {
-        const result = await window.electronAPI.sendIPC(
+        const result = await window.electronAPI.send(
             'show-dialog-message', 
             'warning',
             'Overwrite Current Unsaved Changes?',
@@ -132,7 +132,7 @@ window.electronAPI.on('file-opened', async (event: IpcRendererEvent, file: strin
 
 window.electronAPI.on('file-changed', (event: IpcRendererEvent, file: string, content: string) => {
     if (originalContent !== content) {
-        window.electronAPI.sendIPC(
+        window.electronAPI.send(
             'show-dialog-message',
             'warning',
             'Overwrite Current Unsaved Changes?',
@@ -203,9 +203,9 @@ markdownView.addEventListener('drop', (event: DragEvent) => {
 });
 
 window.electronAPI.on('save-markdown', () => {
-    window.electronAPI.sendIPC('save-markdown', filePath, markdownView.value);
+    window.electronAPI.send('save-markdown', filePath, markdownView.value);
 })
 
 window.electronAPI.on('save-html', () => {
-    window.electronAPI.sendIPC('save-html', htmlView.innerHTML);
+    window.electronAPI.send('save-html', htmlView.innerHTML);
 });


### PR DESCRIPTION
This pull request includes changes to improve the codebase by standardizing the IPC function naming and removing unnecessary console logs. The most important changes include renaming the `sendIPC` method to `send` across multiple files and removing a console log statement in the `createWindow` function.

Standardizing IPC function naming:

* [`src/preload.ts`](diffhunk://#diff-9bf33f12c0002eeec39a2d3439dbe26fb3004ab67f714bb384122169cfaff491L13-R13): Renamed `sendIPC` method to `send` in the `contextBridge.exposeInMainWorld` function.
* [`src/renderer.ts`](diffhunk://#diff-feb7ceb6e19ece5ccb87c867d2c740d1cd0669de790815c5d1107259c0fc0212L52-R53): Updated all instances of `window.electronAPI.sendIPC` to `window.electronAPI.send` for consistency. [[1]](diffhunk://#diff-feb7ceb6e19ece5ccb87c867d2c740d1cd0669de790815c5d1107259c0fc0212L52-R53) [[2]](diffhunk://#diff-feb7ceb6e19ece5ccb87c867d2c740d1cd0669de790815c5d1107259c0fc0212L69-R82) [[3]](diffhunk://#diff-feb7ceb6e19ece5ccb87c867d2c740d1cd0669de790815c5d1107259c0fc0212L92-R92) [[4]](diffhunk://#diff-feb7ceb6e19ece5ccb87c867d2c740d1cd0669de790815c5d1107259c0fc0212L115-R115) [[5]](diffhunk://#diff-feb7ceb6e19ece5ccb87c867d2c740d1cd0669de790815c5d1107259c0fc0212L135-R135) [[6]](diffhunk://#diff-feb7ceb6e19ece5ccb87c867d2c740d1cd0669de790815c5d1107259c0fc0212L206-R210)

Code cleanup:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL72-L73): Removed an unnecessary console log statement in the `createWindow` function.